### PR TITLE
Improve UI responsiveness with worker threads

### DIFF
--- a/SearchEverything.pro
+++ b/SearchEverything.pro
@@ -9,10 +9,14 @@ TEMPLATE = app
 
 SOURCES += \
     main.cpp \
-    mainwindow.cpp
+    mainwindow.cpp \
+    searchworker.cpp \
+    exportworker.cpp
 
 HEADERS += \
-    mainwindow.h
+    mainwindow.h \
+    searchworker.h \
+    exportworker.h
 
 # 默认规则用于调试
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/exportworker.cpp
+++ b/exportworker.cpp
@@ -1,0 +1,23 @@
+#include "exportworker.h"
+#include <QFileInfo>
+
+ExportWorker::ExportWorker(QObject *parent) : QObject(parent)
+{
+    connect(&process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+            this, &ExportWorker::onFinished);
+}
+
+void ExportWorker::start(const QString &rgExePath, const QStringList &arguments, const QString &outputFile)
+{
+    outFile = outputFile;
+    process.setProcessChannelMode(QProcess::MergedChannels);
+    process.setStandardOutputFile(outputFile, QIODevice::Truncate);
+    process.start(rgExePath, arguments);
+}
+
+void ExportWorker::onFinished(int exitCode, QProcess::ExitStatus status)
+{
+    QFileInfo fi(outFile);
+    bool success = (status == QProcess::NormalExit && exitCode == 0 && fi.exists() && fi.size() > 0);
+    emit finished(success);
+}

--- a/exportworker.h
+++ b/exportworker.h
@@ -1,0 +1,27 @@
+#ifndef EXPORTWORKER_H
+#define EXPORTWORKER_H
+
+#include <QObject>
+#include <QProcess>
+
+class ExportWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ExportWorker(QObject *parent = nullptr);
+
+public slots:
+    void start(const QString &rgExePath, const QStringList &arguments, const QString &outputFile);
+
+signals:
+    void finished(bool success);
+
+private slots:
+    void onFinished(int exitCode, QProcess::ExitStatus status);
+
+private:
+    QProcess process;
+    QString outFile;
+};
+
+#endif // EXPORTWORKER_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -8,6 +8,8 @@
 #include <QRadioButton>
 #include <QProcess>
 #include <QThread>
+#include "searchworker.h"
+#include "exportworker.h"
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QFile>
@@ -31,8 +33,9 @@ private slots:
     void onSearchClicked();
     void onStopClicked();
     void onExportClicked();
+    void onExportFinished(bool success);
     void onSearchFinished(int exitCode, QProcess::ExitStatus exitStatus);
-    void onSearchOutput();
+    void onSearchResult(const QString &name, const QString &path);
     void onResultTableContextMenuRequested(const QPoint &pos);
     void onOpenPathAction();
     void onCheckRgVersionClicked();
@@ -66,8 +69,10 @@ private:
     QMenu *resultTableMenu;
     QLineEdit *cmdDisplayEdit;
 
-    QProcess *searchProcess;
-    QProcess* exportProcess = nullptr;
+    QThread *searchThread = nullptr;
+    SearchWorker *searchWorker = nullptr;
+    QThread *exportThread = nullptr;
+    ExportWorker *exportWorker = nullptr;
     QString currentPath;
     QString rgExePath;
     bool isSearching;

--- a/searchworker.cpp
+++ b/searchworker.cpp
@@ -1,0 +1,39 @@
+#include "searchworker.h"
+#include <QFileInfo>
+
+SearchWorker::SearchWorker(QObject *parent) : QObject(parent)
+{
+    connect(&process, &QProcess::readyReadStandardOutput, this, &SearchWorker::onReadyRead);
+    connect(&process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+            this, &SearchWorker::finished);
+}
+
+void SearchWorker::start(const QString &rgExePath, const QStringList &arguments)
+{
+    process.setProcessChannelMode(QProcess::MergedChannels);
+    process.start(rgExePath, arguments);
+}
+
+void SearchWorker::stop()
+{
+    if (process.state() != QProcess::NotRunning) {
+        process.kill();
+    }
+}
+
+void SearchWorker::onReadyRead()
+{
+    QString output = QString::fromUtf8(process.readAllStandardOutput());
+    const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+    for (const QString &line : lines) {
+        QString fullPath = line.trimmed();
+        if (fullPath.isEmpty())
+            continue;
+        if (fullPath.contains("拒绝访问") || fullPath.contains("os error 5"))
+            continue;
+        QFileInfo info(fullPath);
+        if (info.exists()) {
+            emit resultFound(info.fileName(), info.absolutePath());
+        }
+    }
+}

--- a/searchworker.h
+++ b/searchworker.h
@@ -1,0 +1,28 @@
+#ifndef SEARCHWORKER_H
+#define SEARCHWORKER_H
+
+#include <QObject>
+#include <QProcess>
+
+class SearchWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SearchWorker(QObject *parent = nullptr);
+
+public slots:
+    void start(const QString &rgExePath, const QStringList &arguments);
+    void stop();
+
+signals:
+    void resultFound(const QString &name, const QString &path);
+    void finished(int exitCode, QProcess::ExitStatus exitStatus);
+
+private slots:
+    void onReadyRead();
+
+private:
+    QProcess process;
+};
+
+#endif // SEARCHWORKER_H


### PR DESCRIPTION
## Summary
- add `SearchWorker` and `ExportWorker` classes to run `QProcess` in background threads
- update `MainWindow` to use the workers and remove blocking calls
- include new sources in project file

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552ed965888331863f8aa4f8bd5551